### PR TITLE
update to https for removing mixed content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<script type="text/javascript" src="http://code.jquery.com/jquery-3.3.1.min.js">	</script>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js">	</script>
 	<script src="https://cdn.rawgit.com/pszuster/OpenshiftTemplateEditor/master/jsoneditor.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/css/select2.css">


### PR DESCRIPTION
Fixes mixed content warning which doesn't load jquery when running  locally. https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default

![image](https://user-images.githubusercontent.com/23069445/37500626-3ad2bbd6-2916-11e8-9509-969bcc7e336e.png)
